### PR TITLE
Explicitly list dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,10 @@
         "react/http-client": "0.3.*",
         "react/event-loop": "0.3.*",
         "react/socket-client": "0.3.*",
-        "react/socket": "0.3.*"
+        "react/socket": "0.3.*",
+        "react/dns": "0.3.*",
+        "react/stream": "0.3.*",
+        "react/promise": "~1.0",
+        "evenement/evenement": "~1.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,9 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
     ],
-    "hash": "b52b2826c3c96a5473877957f87ab1fe",
+    "hash": "2611546beab1568c17637d0c3709cf93",
     "packages": [
         {
             "name": "evenement/evenement",


### PR DESCRIPTION
Currently, they're (implicitly) installed as part of a dependency of the other dependencies. IMHO this is an implementation detail that we should not rely on.

The resulting dependency graph looks like this:
![graph-composer](https://cloud.githubusercontent.com/assets/776829/3223741/0cf728e0-f027-11e3-8bbc-3917be33d26b.png)
