### PR TITLE
Remove HTTP support and link to clue/buzz-react instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,22 +48,12 @@ $tcp->create('www.google.com',80)->then(function (React\Stream\Stream $stream) {
 
 ### HTTP requests
 
-Or if all you want to do is HTTP requests, `Socks/Client` provides an even simpler [HTTP client](https://github.com/reactphp/http-client) interface:
-```PHP
-$httpclient = $client->createHttpClient();
-
-$request = $httpclient->request('GET', 'https://www.google.com/', array('user-agent'=>'Custom/1.0'));
-$request->on('response', function (React\HttpClient\Response $response) {
-    var_dump('Headers received:', $response->getHeaders());
-    
-    // dump whole response body
-    $response->on('data', function ($data) {
-        echo $data;
-    });
-});
-$request->end();
-```
-Yes, this works for both plain HTTP and SSL encrypted HTTPS requests.
+HTTP operates on a higher layer than this low-level SOCKS implementation.
+If you want to issue HTTP requests, you can add a dependency for
+[clue/buzz-react](https://github.com/clue/php-buzz-react).
+It can interact with this library by issuing all
+[http requests through a SOCKS server](https://github.com/clue/php-buzz-react/#via-socks-server).
+This works for both plain HTTP and SSL encrypted HTTPS requests.
 
 ### SSL/TLS encrypted
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
     },
     "require": {
         "php": ">=5.3",
-        "react/http-client": "0.3.*",
         "react/event-loop": "0.3.*",
         "react/socket-client": "0.3.*",
         "react/socket": "0.3.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2134dc2629b011a30cd1635dc7c1dd4b",
+    "hash": "10f5ad1a61dcc495ce79b8c5895ff236",
     "packages": [
         {
             "name": "evenement/evenement",
@@ -45,45 +45,6 @@
                 "event-dispatcher"
             ],
             "time": "2012-05-30 15:01:08"
-        },
-        {
-            "name": "guzzle/parser",
-            "version": "v2.8.8",
-            "target-dir": "Guzzle/Parser",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/parser.git",
-                "reference": "8f5152833af2d9505bcefb0a10c4b6987aa9a6b1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/parser/zipball/8f5152833af2d9505bcefb0a10c4b6987aa9a6b1",
-                "reference": "8f5152833af2d9505bcefb0a10c4b6987aa9a6b1",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Guzzle\\Parser": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Interchangeable parsers used by Guzzle",
-            "homepage": "http://guzzlephp.org/",
-            "keywords": [
-                "URI Template",
-                "cookie",
-                "http",
-                "message",
-                "url"
-            ],
-            "time": "2012-09-20 20:28:06"
         },
         {
             "name": "react/cache",
@@ -210,48 +171,6 @@
                 "event-loop"
             ],
             "time": "2013-07-08 22:38:22"
-        },
-        {
-            "name": "react/http-client",
-            "version": "v0.3.2",
-            "target-dir": "React/HttpClient",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/reactphp/http-client.git",
-                "reference": "b96aa5dfa23c83e669de8d4acb717b03ae70c088"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/http-client/zipball/b96aa5dfa23c83e669de8d4acb717b03ae70c088",
-                "reference": "b96aa5dfa23c83e669de8d4acb717b03ae70c088",
-                "shasum": ""
-            },
-            "require": {
-                "guzzle/parser": "2.8.*",
-                "php": ">=5.3.3",
-                "react/dns": "0.3.*",
-                "react/socket-client": "0.3.*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "React\\HttpClient": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Asynchronous HTTP client library.",
-            "keywords": [
-                "http"
-            ],
-            "time": "2013-04-21 12:54:33"
         },
         {
             "name": "react/promise",
@@ -436,6 +355,7 @@
     "stability-flags": [
 
     ],
+    "prefer-stable": false,
     "platform": {
         "php": ">=5.3"
     },

--- a/examples/client.php
+++ b/examples/client.php
@@ -2,8 +2,6 @@
 
 use ConnectionManager\SecureConnectionManager;
 use React\Promise\PromiseInterface;
-use React\HttpClient\Client as HttpClient;
-use React\HttpClient\Response;
 use React\Stream\Stream;
 
 include_once __DIR__.'/../vendor/autoload.php';
@@ -85,20 +83,6 @@ assertFail($ssl->create('www.google.com', 8080), 'ssl://www.google.com:8080');
 //         echo $data;
 //     });
 // });
-
-// $factory = new React\HttpClient\Factory();
-// $httpclient = $factory->create($loop, $dns);
-$httpclient = $client->createHttpClient();
-
-$request = $httpclient->request('GET', 'https://www.google.com/', array('user-agent'=>'none'));
-$request->on('response', function (Response $response) {
-    echo '[response1]' . PHP_EOL;
-    //var_dump($response->getHeaders());
-    $response->on('data', function ($data) {
-        echo $data;
-    });
-});
-$request->end();
 
 $loop->addTimer(8, function() use ($loop) {
     $loop->stop();

--- a/src/Client.php
+++ b/src/Client.php
@@ -4,7 +4,6 @@ namespace Clue\React\Socks;
 
 use React\Promise\When;
 use React\Promise\Deferred;
-use React\HttpClient\Client as HttpClient;
 use React\Dns\Resolver\Resolver;
 use React\Stream\Stream;
 use React\EventLoop\LoopInterface;
@@ -107,11 +106,6 @@ class Client
     public function unsetAuth()
     {
         $this->auth = null;
-    }
-
-    public function createHttpClient()
-    {
-        return new HttpClient($this->loop, $this->createConnector(), $this->createSecureConnector());
     }
 
     public function createSecureConnector()

--- a/tests/ClientApiTest.php
+++ b/tests/ClientApiTest.php
@@ -120,11 +120,6 @@ class ClientApiTest extends TestCase
         $this->client->setTimeout(3);
     }
 
-    public function testCreateHttpClient()
-    {
-        $this->assertInstanceOf('\React\HttpClient\Client', $this->client->createHttpClient());
-    }
-
     public function testCreateConnector()
     {
         $this->assertInstanceOf('\React\SocketClient\ConnectorInterface', $this->client->createConnector());


### PR DESCRIPTION
Drop dependency on react/http-client and remove related methods

Fixes #2
