### PR TITLE
Support Promise cancellation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "react/socket-client": "^0.5",
         "react/dns": "0.3.*|0.4.*",
         "react/stream": "0.3.*|0.4.*",
-        "react/promise": "~1.0|~2.0"
+        "react/promise": "^2.1 || ^1.2"
     },
     "require-dev": {
         "clue/socks-server": "^0.5",

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "react/promise": "~1.0|~2.0"
     },
     "require-dev": {
-        "clue/socks-server": "^0.5"
+        "clue/socks-server": "^0.5",
+        "clue/block-react": "^1.1"
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Clue\React\Socks\Client;
+use React\Promise\Promise;
 
 class ClientTest extends TestCase
 {
@@ -146,6 +147,76 @@ class ClientTest extends TestCase
     public function testCreateSecureConnector()
     {
         $this->assertInstanceOf('\React\SocketClient\SecureConnector', $this->client->createSecureConnector());
+    }
+
+    public function testCancelConnectionDuringConnectionWillCancelConnection()
+    {
+        $promise = new Promise(function () { }, $this->expectCallableOnce());
+
+        $connector = $this->getMock('React\SocketClient\ConnectorInterface');
+        $connector->expects($this->once())->method('create')->with('127.0.0.1', 1080)->willReturn($promise);
+        $this->client = new Client('127.0.0.1', $this->loop, $connector);
+
+        $promise = $this->client->createConnection('google.com', 80);
+        $promise->cancel();
+
+        $this->expectPromiseReject($promise);
+    }
+
+    public function testCancelConnectionDuringConnectionWillCancelConnectionAndCloseStreamIfItResolvesDespite()
+    {
+        $stream = $this->getMockBuilder('React\Stream\Stream')->disableOriginalConstructor()->getMock();
+        $stream->expects($this->once())->method('close');
+
+        $promise = new Promise(function () { }, function ($resolve) use ($stream) { $resolve($stream); });
+
+        $connector = $this->getMock('React\SocketClient\ConnectorInterface');
+        $connector->expects($this->once())->method('create')->with('127.0.0.1', 1080)->willReturn($promise);
+        $this->client = new Client('127.0.0.1', $this->loop, $connector);
+
+        $promise = $this->client->createConnection('google.com', 80);
+        $promise->cancel();
+
+        $this->expectPromiseReject($promise);
+    }
+
+    public function testCancelConnectionDuringDnsWillCancelDns()
+    {
+        $stream = $this->getMockBuilder('React\Stream\Stream')->disableOriginalConstructor()->getMock();
+        $promise = new Promise(function ($resolve) use ($stream) { $resolve($stream); });
+
+        $connector = $this->getMock('React\SocketClient\ConnectorInterface');
+        $connector->expects($this->once())->method('create')->with('127.0.0.1', 1080)->willReturn($promise);
+
+        $promise = new Promise(function () { }, $this->expectCallableOnce());
+
+        $resolver = $this->getMockBuilder('React\Dns\Resolver\Resolver')->disableOriginalConstructor()->getMock();
+        $resolver->expects($this->once())->method('resolve')->with('google.com')->willReturn($promise);
+
+        $this->client = new Client('127.0.0.1', $this->loop, $connector, $resolver);
+
+        $promise = $this->client->createConnection('google.com', 80);
+        $promise->cancel();
+
+        $this->expectPromiseReject($promise);
+    }
+
+    public function testCancelConnectionDuringSessionWillCloseStream()
+    {
+        $stream = $this->getMockBuilder('React\Stream\Stream')->disableOriginalConstructor()->getMock();
+        $stream->expects($this->once())->method('close');
+
+        $promise = new Promise(function ($resolve) use ($stream) { $resolve($stream); });
+
+        $connector = $this->getMock('React\SocketClient\ConnectorInterface');
+        $connector->expects($this->once())->method('create')->with('127.0.0.1', 1080)->willReturn($promise);
+        $this->client = new Client('127.0.0.1', $this->loop, $connector);
+        $this->client->setResolveLocal(false);
+
+        $promise = $this->client->createConnection('google.com', 80);
+        $promise->cancel();
+
+        $this->expectPromiseReject($promise);
     }
 
     /**

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -113,6 +113,16 @@ class FunctionalTest extends TestCase
         $this->assertRejectPromise($tcp->create('www.google.commm', 80));
     }
 
+    public function testConnectorCancelConnection()
+    {
+        $tcp = $this->client->createConnector();
+
+        $promise = $tcp->create('www.google.com', 80);
+        $promise->cancel();
+
+        $this->assertRejectPromise($promise);
+    }
+
     public function testConnectorInvalidUnboundPortTimeout()
     {
         $this->client->setTimeout(0.1);

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -3,7 +3,7 @@
 use React\Stream\Stream;
 use Clue\React\Socks\Client;
 use Clue\React\Socks\Server\Server;
-use React\Promise\PromiseInterface;
+use Clue\React\Block;
 
 class FunctionalTest extends TestCase
 {
@@ -189,7 +189,7 @@ class FunctionalTest extends TestCase
             $stream->close();
         });
 
-        $this->waitFor($promise);
+        Block\await($promise, $this->loop, 2.0);
     }
 
     private function assertRejectPromise($promise)
@@ -197,28 +197,7 @@ class FunctionalTest extends TestCase
         $this->expectPromiseReject($promise);
 
         $this->setExpectedException('Exception');
-        $this->waitFor($promise);
-    }
 
-    private function waitFor(PromiseInterface $promise)
-    {
-        $resolved = null;
-        $exception = null;
-
-        $promise->then(function ($c) use (&$resolved) {
-            $resolved = $c;
-        }, function($error) use (&$exception) {
-            $exception = $error;
-        });
-
-        while ($resolved === null && $exception === null) {
-            $this->loop->tick();
-        }
-
-        if ($exception !== null) {
-            throw $exception;
-        }
-
-        return $resolved;
+        Block\await($promise, $this->loop, 2.0);
     }
 }


### PR DESCRIPTION
We now register a Promise cancellation handler so that the following code actually cleans up the underlying socket resource:

```php
$promise = $connector->create('reactphp.org', 80);

$promise->cancel();
```

Closes #30 
