### PR TITLE
Apply protocol version and username/password auth from SOCKS URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,14 @@ In general this library automatically switches to higher protocol versions
 when needed, but tries to keep things simple otherwise and sticks to lower
 protocol versions when possible.
 
-If want to explicitly set the protocol version, use the supported values `4`, `4a` or `5`:
+If want to explicitly set the protocol version, use the supported values `4`, `4a` or `5`
+as part of the SOCKS URI:
+
+```php
+$client = new Client('socks4a://127.0.0.1', $loop);
+```
+
+You can also explicitly set the protocol version later:
 
 ```PHP
 $client->setProtocolVersion('4a');
@@ -266,7 +273,28 @@ Authentication is only supported by protocol version 5 (SOCKS5),
 so setting authentication on the `Client` enforces communication with protocol
 version 5 and complains if you have explicitly set anything else. 
 
-```PHP
+You can simply pass the authentication information as part of the SOCKS URI:
+
+```php
+$client = new Client('username:password@127.0.0.1', $loop);
+```
+
+Note that both the username and password must be percent-encoded if they contain
+special characters:
+
+```php
+$user = 'he:llo';
+$pass = 'p@ss';
+
+$client = new Client(
+    rawurlencode($user) . ':' . rawurlencode($pass) . '@127.0.0.1',
+    $loop
+);
+```
+
+You can also explicitly set the authentication information later:
+
+```php
 $client->setAuth('username', 'password');
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "react/promise": "^2.1 || ^1.2"
     },
     "require-dev": {
-        "clue/socks-server": "^0.5",
+        "clue/socks-server": "^0.5.1",
         "clue/block-react": "^1.1"
     }
 }

--- a/examples/01-http.php
+++ b/examples/01-http.php
@@ -12,8 +12,6 @@ $loop = React\EventLoop\Factory::create();
 $client = new Client('127.0.0.1:' . $port, $loop);
 $client->setTimeout(3.0);
 $client->setResolveLocal(false);
-// $client->setProtocolVersion(5);
-// $client->setAuth('test','test');
 
 echo 'Demo SOCKS client connecting to SOCKS server 127.0.0.1:' . $port . PHP_EOL;
 echo 'Not already running a SOCKS server? Try this: ssh -D ' . $port . ' localhost' . PHP_EOL;

--- a/examples/02-https.php
+++ b/examples/02-https.php
@@ -12,8 +12,6 @@ $loop = React\EventLoop\Factory::create();
 $client = new Client('127.0.0.1:' . $port, $loop);
 $client->setTimeout(3.0);
 $client->setResolveLocal(false);
-// $client->setProtocolVersion(5);
-// $client->setAuth('test','test');
 
 echo 'Demo SOCKS client connecting to SOCKS server 127.0.0.1:' . $port . PHP_EOL;
 echo 'Not already running a SOCKS server? Try this: ssh -D ' . $port . ' localhost' . PHP_EOL;

--- a/src/Client.php
+++ b/src/Client.php
@@ -77,6 +77,15 @@ class Client
             $connector = new DnsConnector(new TcpConnector($loop), $resolver);
         }
 
+        if ($parts['scheme'] !== 'socks') {
+            $this->setProtocolVersion(substr($parts['scheme'], 5));
+        }
+
+        if (isset($parts['user']) || isset($parts['pass'])) {
+            $parts += array('user' => '', 'pass' => '');
+            $this->setAuth(rawurldecode($parts['user']), rawurldecode($parts['pass']));
+        }
+
         $this->loop = $loop;
         $this->socksHost = $parts['host'];
         $this->socksPort = $parts['port'];

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -68,6 +68,11 @@ class ClientTest extends TestCase
         $this->assertNull($this->client->setProtocolVersion(5));
     }
 
+    public function testValidAuthAndVersionFromUri()
+    {
+        $this->client = new Client('socks5://username:password@127.0.0.1:9050', $this->loop);
+    }
+
     /**
      * @expectedException UnexpectedValueException
      */
@@ -75,6 +80,14 @@ class ClientTest extends TestCase
     {
         $this->client->setProtocolVersion(4);
         $this->client->setAuth('username', 'password');
+    }
+
+    /**
+     * @expectedException UnexpectedValueException
+     */
+    public function testInvalidCanNotSetAuthenticationForSocks4Uri()
+    {
+        $this->client = new Client('socks4://username:password@127.0.0.1:9050', $this->loop);
     }
 
     public function testUnsetAuth()


### PR DESCRIPTION
Refs #25. The mutable API will be removed in a follow-up PR that targets the v0.6.0 release.