### PR TITLE
Replace deprecated SocketClient with Socket v0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ to google.com via a local SOCKS proxy server:
 $loop = React\EventLoop\Factory::create();
 $client = new Client('127.0.0.1:9050', new TcpConnector($loop));
 
-$client->connect('tcp://www.google.com:80')->then(function (Stream $stream) {
+$client->connect('tcp://www.google.com:80')->then(function (ConnectionInterface $stream) {
     $stream->write("GET / HTTP/1.0\r\n\r\n");
 });
 
@@ -57,7 +57,7 @@ establishing streaming connections, such as a normal TCP/IP connection.
 In order to use this library, you should understand how this integrates with its
 ecosystem.
 This base interface is actually defined in React's
-[SocketClient component](https://github.com/reactphp/socket-client) and used
+[Socket component](https://github.com/reactphp/socket) and used
 throughout React's ecosystem.
 
 Most higher-level components (such as HTTP, database or other networking
@@ -71,15 +71,15 @@ The interface only offers a single method:
 
 #### connect()
 
-The `connect(string $uri): PromiseInterface<Stream, Exception>` method
+The `connect(string $uri): PromiseInterface<ConnectionInterface, Exception>` method
 can be used to establish a streaming connection.
 It returns a [Promise](https://github.com/reactphp/promise) which either
-fulfills with a [Stream](https://github.com/reactphp/stream) or
+fulfills with a [ConnectionInterface](https://github.com/reactphp/socket#connectioninterface) or
 rejects with an `Exception`:
 
 ```php
 $connector->connect('tcp://google.com:80')->then(
-    function (Stream $stream) {
+    function (ConnectionInterface $stream) {
         // connection successfully established
     },
     function (Exception $error) {
@@ -95,11 +95,11 @@ Its constructor simply accepts an SOCKS proxy URI and a connector used to
 connect to the SOCKS proxy server address.
 
 In its most simple form, you can simply pass React's
-[`TcpConnector`](https://github.com/reactphp/socket-client#tcpconnector)
+[`TcpConnector`](https://github.com/reactphp/socket#tcpconnector)
 like this:
 
 ```php
-$connector = new React\SocketClient\TcpConnector($loop);
+$connector = new React\Socket\TcpConnector($loop);
 $client = new Client('127.0.0.1:1080', $connector);
 
 You can omit the port if you're using the default SOCKS port 1080:
@@ -109,7 +109,7 @@ $client = new Client('127.0.0.1', $connector);
 ```
 
 If you need custom connector settings (DNS resolution, timeouts etc.), you can explicitly pass a
-custom instance of the [`ConnectorInterface`](https://github.com/reactphp/socket-client#connectorinterface):
+custom instance of the [`ConnectorInterface`](https://github.com/reactphp/socket#connectorinterface):
 
 ```php
 // use local DNS server
@@ -145,7 +145,7 @@ hence provides a single public method, the [`connect()`](#connect) method.
 Let's open up a streaming TCP/IP connection and write some data:
 
 ```php
-$client->connect('tcp://www.google.com:80')->then(function (React\Stream\Stream $stream) {
+$client->connect('tcp://www.google.com:80')->then(function (ConnectonInterface $stream) {
     echo 'connected to www.google.com:80';
     $stream->write("GET / HTTP/1.0\r\n\r\n");
     // ...
@@ -173,13 +173,13 @@ the resulting promise.
 
 If you want to establish a secure TLS connection (such as HTTPS) between you and
 your destination, you may want to wrap this connector in React's
-[`SecureConnector`](https://github.com/reactphp/socket-client#secureconnector):
+[`SecureConnector`](https://github.com/reactphp/socket#secureconnector):
 
 ```php
-$ssl = new React\SocketClient\SecureConnector($client, $loop);
+$ssl = new React\Socket\SecureConnector($client, $loop);
 
 // now create an SSL encrypted connection (notice the $ssl instead of $tcp)
-$ssl->connect('tls://www.google.com:443')->then(function (React\Stream\Stream $stream) {
+$ssl->connect('tls://www.google.com:443')->then(function (ConnectionInterface $stream) {
     // proceed with just the plain text data
     // everything is encrypted/decrypted automatically
     echo 'connected to SSL encrypted www.google.com';
@@ -204,7 +204,7 @@ You can optionally pass additional
 to the constructor like this:
 
 ```php
-$ssl = new React\SocketClient\SecureConnector($client, $loop, array(
+$ssl = new React\Socket\SecureConnector($client, $loop, array(
     'verify_peer' => false,
     'verify_peer_name' => false
 ));
@@ -333,10 +333,10 @@ $factory = new React\Dns\Resolver\Factory();
 $resolver = $factory->createCached('8.8.8.8', $loop);
 
 // resolve hostnames via DNS before forwarding resulting IP trough SOCKS server
-$dns = new React\SocketClient\DnsConnector($client, $resolver);
+$dns = new React\Socket\DnsConnector($client, $resolver);
 
 // secure TLS via the DNS connector
-$ssl = new React\SocketClient\SecureConnector($dns, $loop);
+$ssl = new React\Socket\SecureConnector($dns, $loop);
 
 $ssl->connect('tls://www.google.com:443')->then(function ($stream) {
     // …
@@ -429,7 +429,7 @@ SOCKS connector from another SOCKS client like this:
 $middle = new Client($addressMiddle, new TcpConnector($loop));
 $target = new Client($addressTarget, $middle);
 
-$ssl = new React\SocketClient\SecureConnector($target, $loop);
+$ssl = new React\Socket\SecureConnector($target, $loop);
 
 $ssl->connect('tls://www.google.com:443')->then(function ($stream) {
     // …
@@ -466,13 +466,13 @@ Many use cases require more control over the timeout and likely values much
 smaller, usually in the range of a few seconds only.
 
 You can use React's
-[`TimeoutConnector`](https://github.com/reactphp/socket-client#timeoutconnector)
+[`TimeoutConnector`](https://github.com/reactphp/socket#timeoutconnector)
 to decorate any given `ConnectorInterface` instance.
 It provides the same `connect()` method, but will automatically reject the
 underlying connection attempt if it takes too long:
 
 ```php
-$timeoutConnector = new React\SocketClient\TimeoutConnector($connector, 3.0, $loop);
+$timeoutConnector = new React\Socket\TimeoutConnector($connector, 3.0, $loop);
 
 $timeoutConnector->connect('tcp://google.com:80')->then(function ($stream) {
     // connection succeeded within 3.0 seconds
@@ -564,7 +564,7 @@ MIT, see LICENSE
 * If you want to learn more about how the
   [`ConnectorInterface`](#connectorinterface) and its usual implementations look
   like, refer to the documentation of the underlying
-  [react/socket-client](https://github.com/reactphp/socket-client) component.
+  [react/socket component](https://github.com/reactphp/socket).
 * As an alternative to a SOCKS (SOCKS4/SOCKS5) proxy, you may also want to look into
   using an HTTP CONNECT proxy instead.
   You may want to use [clue/http-proxy-react](https://github.com/clue/php-http-proxy-react)

--- a/composer.json
+++ b/composer.json
@@ -15,15 +15,14 @@
     },
     "require": {
         "php": ">=5.3",
-        "react/socket-client": "^0.7 || ^0.6",
+        "react/socket": "^0.7",
         "react/stream": "^0.6 || ^0.5 || ^0.4 || ^0.3",
         "react/promise": "^2.1 || ^1.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0 || ^4.8",
         "react/event-loop": "0.3.*|0.4.*",
-        "react/dns": "0.3.*|0.4.*",
-        "clue/socks-server": "^0.5.1",
+        "clue/socks-server": "^0.7",
         "clue/block-react": "^1.1"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     },
     "require": {
         "php": ">=5.3",
-        "react/socket-client": "^0.5.1",
-        "react/stream": "0.3.*|0.4.*",
+        "react/socket-client": "^0.7 || ^0.6",
+        "react/stream": "^0.6 || ^0.5 || ^0.4 || ^0.3",
         "react/promise": "^2.1 || ^1.2"
     },
     "require-dev": {

--- a/examples/01-http.php
+++ b/examples/01-http.php
@@ -1,8 +1,9 @@
 <?php
 
 use Clue\React\Socks\Client;
-use React\SocketClient\TcpConnector;
-use React\SocketClient\TimeoutConnector;
+use React\Socket\TcpConnector;
+use React\Socket\ConnectionInterface;
+use React\Socket\Connector;
 
 include_once __DIR__.'/../vendor/autoload.php';
 
@@ -11,14 +12,16 @@ $port = isset($argv[1]) ? $argv[1] : 9050;
 $loop = React\EventLoop\Factory::create();
 
 $client = new Client('127.0.0.1:' . $port, new TcpConnector($loop));
+$connector = new Connector($loop, array(
+    'tcp' => $client,
+    'timeout' => 3.0,
+    'dns' => false
+));
 
 echo 'Demo SOCKS client connecting to SOCKS server 127.0.0.1:' . $port . PHP_EOL;
 echo 'Not already running a SOCKS server? Try this: ssh -D ' . $port . ' localhost' . PHP_EOL;
 
-// time out connection attempt in 3.0s
-$tcp = new TimeoutConnector($client, 3.0, $loop);
-
-$tcp->connect('tcp://www.google.com:80')->then(function (Stream $stream) {
+$connector->connect('tcp://www.google.com:80')->then(function (ConnectionInterface $stream) {
     echo 'connected' . PHP_EOL;
     $stream->write("GET / HTTP/1.0\r\n\r\n");
     $stream->on('data', function ($data) {

--- a/examples/01-http.php
+++ b/examples/01-http.php
@@ -1,6 +1,5 @@
 <?php
 
-use React\Stream\Stream;
 use Clue\React\Socks\Client;
 use React\SocketClient\TcpConnector;
 use React\SocketClient\TimeoutConnector;
@@ -19,7 +18,7 @@ echo 'Not already running a SOCKS server? Try this: ssh -D ' . $port . ' localho
 // time out connection attempt in 3.0s
 $tcp = new TimeoutConnector($client, 3.0, $loop);
 
-$tcp->create('www.google.com', 80)->then(function (Stream $stream) {
+$tcp->connect('tcp://www.google.com:80')->then(function (Stream $stream) {
     echo 'connected' . PHP_EOL;
     $stream->write("GET / HTTP/1.0\r\n\r\n");
     $stream->on('data', function ($data) {

--- a/examples/02-https.php
+++ b/examples/02-https.php
@@ -1,10 +1,9 @@
 <?php
 
-use React\Stream\Stream;
 use Clue\React\Socks\Client;
-use React\SocketClient\TcpConnector;
-use React\SocketClient\SecureConnector;
-use React\SocketClient\TimeoutConnector;
+use React\Socket\TcpConnector;
+use React\Socket\ConnectionInterface;
+use React\Socket\Connector;
 
 include_once __DIR__.'/../vendor/autoload.php';
 
@@ -13,16 +12,16 @@ $port = isset($argv[1]) ? $argv[1] : 9050;
 $loop = React\EventLoop\Factory::create();
 
 $client = new Client('127.0.0.1:' . $port, new TcpConnector($loop));
+$connector = new Connector($loop, array(
+    'tcp' => $client,
+    'timeout' => 3.0,
+    'dns' => false
+));
 
 echo 'Demo SOCKS client connecting to SOCKS server 127.0.0.1:' . $port . PHP_EOL;
 echo 'Not already running a SOCKS server? Try this: ssh -D ' . $port . ' localhost' . PHP_EOL;
 
-$ssl = new SecureConnector($client, $loop);
-
-// time out connection attempt in 3.0s
-$ssl = new TimeoutConnector($ssl, 3.0, $loop);
-
-$ssl->connect('tls://www.google.com:443')->then(function (Stream $stream) {
+$connector->connect('tls://www.google.com:443')->then(function (ConnectionInterface $stream) {
     echo 'connected' . PHP_EOL;
     $stream->write("GET / HTTP/1.0\r\n\r\n");
     $stream->on('data', function ($data) {

--- a/examples/02-https.php
+++ b/examples/02-https.php
@@ -22,7 +22,7 @@ $ssl = new SecureConnector($client, $loop);
 // time out connection attempt in 3.0s
 $ssl = new TimeoutConnector($ssl, 3.0, $loop);
 
-$ssl->create('www.google.com', 443)->then(function (Stream $stream) {
+$ssl->connect('tls://www.google.com:443')->then(function (Stream $stream) {
     echo 'connected' . PHP_EOL;
     $stream->write("GET / HTTP/1.0\r\n\r\n");
     $stream->on('data', function ($data) {

--- a/examples/03-proxy-chaining.php
+++ b/examples/03-proxy-chaining.php
@@ -23,7 +23,7 @@ $ssl = new SecureConnector($bar, $loop);
 echo 'Demo SOCKS client connecting to SOCKS proxy server chain 127.0.0.1:' . $first . ' and 127.0.0.1:' . $second . PHP_EOL;
 echo 'Not already running a SOCKS server? Try this: ssh -D ' . $first . ' localhost' . PHP_EOL;
 
-$ssl->create('www.google.com', 443)->then(function (Stream $stream) {
+$ssl->connect('tls://www.google.com:443')->then(function (Stream $stream) {
     echo 'connected' . PHP_EOL;
     $stream->write("GET / HTTP/1.0\r\n\r\n");
     $stream->on('data', function ($data) {

--- a/examples/03-proxy-chaining.php
+++ b/examples/03-proxy-chaining.php
@@ -1,9 +1,9 @@
 <?php
 
-use React\Stream\Stream;
 use Clue\React\Socks\Client;
-use React\SocketClient\TcpConnector;
-use React\SocketClient\SecureConnector;
+use React\Socket\TcpConnector;
+use React\Socket\ConnectionInterface;
+use React\Socket\Connector;
 
 include_once __DIR__.'/../vendor/autoload.php';
 
@@ -18,12 +18,16 @@ $loop = React\EventLoop\Factory::create();
 $foo = new Client('127.0.0.1:' . $first, new TcpConnector($loop));
 $bar = new Client('127.0.0.1:' . $second, $foo);
 
-$ssl = new SecureConnector($bar, $loop);
+$connector = new Connector($loop, array(
+    'tcp' => $bar,
+    'timeout' => 3.0,
+    'dns' => false
+));
 
 echo 'Demo SOCKS client connecting to SOCKS proxy server chain 127.0.0.1:' . $first . ' and 127.0.0.1:' . $second . PHP_EOL;
 echo 'Not already running a SOCKS server? Try this: ssh -D ' . $first . ' localhost' . PHP_EOL;
 
-$ssl->connect('tls://www.google.com:443')->then(function (Stream $stream) {
+$connector->connect('tls://www.google.com:443')->then(function (ConnectionInterface $stream) {
     echo 'connected' . PHP_EOL;
     $stream->write("GET / HTTP/1.0\r\n\r\n");
     $stream->on('data', function ($data) {

--- a/examples/04-local-dns.php
+++ b/examples/04-local-dns.php
@@ -1,12 +1,9 @@
 <?php
 
-use React\Stream\Stream;
 use Clue\React\Socks\Client;
-use React\Dns\Resolver\Factory;
-use React\SocketClient\TcpConnector;
-use React\SocketClient\DnsConnector;
-use React\SocketClient\SecureConnector;
-use React\SocketClient\TimeoutConnector;
+use React\Socket\TcpConnector;
+use React\Socket\ConnectionInterface;
+use React\Socket\Connector;
 
 include_once __DIR__.'/../vendor/autoload.php';
 
@@ -14,24 +11,18 @@ $port = isset($argv[1]) ? $argv[1] : 9050;
 
 $loop = React\EventLoop\Factory::create();
 
-$client = new Client('127.0.0.1:' . $port, new TcpConnector($loop));
-
 // set up DNS server to use (Google's public DNS)
-$factory = new Factory();
-$resolver = $factory->createCached('8.8.8.8', $loop);
-
-// resolve hostnames via DNS before forwarding resulting IP trough SOCKS server
-$dns = new DnsConnector($client, $resolver);
+$client = new Client('127.0.0.1:' . $port, new TcpConnector($loop));
+$connector = new Connector($loop, array(
+    'tcp' => $client,
+    'timeout' => 3.0,
+    'dns' => '8.8.8.8'
+));
 
 echo 'Demo SOCKS client connecting to SOCKS server 127.0.0.1:' . $port . PHP_EOL;
 echo 'Not already running a SOCKS server? Try this: ssh -D ' . $port . ' localhost' . PHP_EOL;
 
-$ssl = new SecureConnector($dns, $loop);
-
-// time out connection attempt in 3.0s
-$ssl = new TimeoutConnector($ssl, 3.0, $loop);
-
-$ssl->create('tls://www.google.com:443')->then(function (Stream $stream) {
+$connector->connect('tls://www.google.com:443')->then(function (ConnectionInterface $stream) {
     echo 'connected' . PHP_EOL;
     $stream->write("GET / HTTP/1.0\r\n\r\n");
     $stream->on('data', function ($data) {

--- a/examples/04-local-dns.php
+++ b/examples/04-local-dns.php
@@ -31,7 +31,7 @@ $ssl = new SecureConnector($dns, $loop);
 // time out connection attempt in 3.0s
 $ssl = new TimeoutConnector($ssl, 3.0, $loop);
 
-$ssl->create('www.google.com', 443)->then(function (Stream $stream) {
+$ssl->create('tls://www.google.com:443')->then(function (Stream $stream) {
     echo 'connected' . PHP_EOL;
     $stream->write("GET / HTTP/1.0\r\n\r\n");
     $stream->on('data', function ($data) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -3,11 +3,10 @@
 namespace Clue\React\Socks;
 
 use React\Promise;
-use React\Promise\CancellablePromiseInterface;
 use React\Promise\PromiseInterface;
 use React\Promise\Deferred;
-use React\SocketClient\ConnectionInterface;
-use React\SocketClient\ConnectorInterface;
+use React\Socket\ConnectionInterface;
+use React\Socket\ConnectorInterface;
 use \Exception;
 use \InvalidArgumentException;
 use RuntimeException;

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -1,12 +1,11 @@
 <?php
 
-use React\Stream\Stream;
 use Clue\React\Socks\Client;
 use Clue\React\Socks\Server\Server;
 use Clue\React\Block;
-use React\SocketClient\TimeoutConnector;
-use React\SocketClient\SecureConnector;
-use React\SocketClient\TcpConnector;
+use React\Socket\TimeoutConnector;
+use React\Socket\SecureConnector;
+use React\Socket\TcpConnector;
 
 class FunctionalTest extends TestCase
 {
@@ -20,8 +19,8 @@ class FunctionalTest extends TestCase
     {
         $this->loop = React\EventLoop\Factory::create();
 
-        $socket = $this->createSocketServer();
-        $this->port = $socket->getPort();
+        $socket = new React\Socket\Server(0, $this->loop);
+        $this->port = parse_url('tcp://' . $socket->getAddress(), PHP_URL_PORT);
         $this->assertNotEquals(0, $this->port);
 
         $this->server = new Server($this->loop, $socket);
@@ -208,14 +207,6 @@ class FunctionalTest extends TestCase
         $ssl = new TimeoutConnector($ssl, 0.1, $this->loop);
 
         $this->assertRejectPromise($ssl->connect('www.google.com:8080'));
-    }
-
-    private function createSocketServer()
-    {
-        $socket = new React\Socket\Server($this->loop);
-        $socket->listen(0);
-
-        return $socket;
     }
 
     private function assertResolveStream($promise)

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -31,7 +31,7 @@ class FunctionalTest extends TestCase
 
     public function testConnection()
     {
-        $this->assertResolveStream($this->client->create('www.google.com', 80));
+        $this->assertResolveStream($this->client->connect('www.google.com:80'));
     }
 
     public function testConnectionWithIpViaSocks4()
@@ -39,26 +39,26 @@ class FunctionalTest extends TestCase
         $this->server->setProtocolVersion(4);
         $this->client = new Client('socks4://127.0.0.1:' . $this->port, $this->connector);
 
-        $this->assertResolveStream($this->client->create('127.0.0.1', $this->port));
+        $this->assertResolveStream($this->client->connect('127.0.0.1:' . $this->port));
     }
 
     public function testConnectionWithHostnameViaSocks4Fails()
     {
         $this->client = new Client('socks4://127.0.0.1:' . $this->port, $this->connector);
 
-        $this->assertRejectPromise($this->client->create('www.google.com', 80));
+        $this->assertRejectPromise($this->client->connect('www.google.com:80'));
     }
 
     public function testConnectionWithInvalidPortFails()
     {
-        $this->assertRejectPromise($this->client->create('www.google.com', 100000));
+        $this->assertRejectPromise($this->client->connect('www.google.com:100000'));
     }
 
     public function testConnectionWithIpv6ViaSocks4Fails()
     {
         $this->client = new Client('socks4://127.0.0.1:' . $this->port, $this->connector);
 
-        $this->assertRejectPromise($this->client->create('::1', 80));
+        $this->assertRejectPromise($this->client->connect('[::1]:80'));
     }
 
     public function testConnectionSocks5()
@@ -66,7 +66,7 @@ class FunctionalTest extends TestCase
         $this->server->setProtocolVersion(5);
         $this->client = new Client('socks5://127.0.0.1:' . $this->port, $this->connector);
 
-        $this->assertResolveStream($this->client->create('www.google.com', 80));
+        $this->assertResolveStream($this->client->connect('www.google.com:80'));
     }
 
     public function testConnectionAuthenticationFromUri()
@@ -75,7 +75,7 @@ class FunctionalTest extends TestCase
 
         $this->client = new Client('name:pass@127.0.0.1:' . $this->port, $this->connector);
 
-        $this->assertResolveStream($this->client->create('www.google.com', 80));
+        $this->assertResolveStream($this->client->connect('www.google.com:80'));
     }
 
     public function testConnectionAuthenticationFromUriEncoded()
@@ -84,7 +84,7 @@ class FunctionalTest extends TestCase
 
         $this->client = new Client(rawurlencode('name') . ':' . rawurlencode('p@ss:w0rd') . '@127.0.0.1:' . $this->port, $this->connector);
 
-        $this->assertResolveStream($this->client->create('www.google.com', 80));
+        $this->assertResolveStream($this->client->connect('www.google.com:80'));
     }
 
     public function testConnectionAuthenticationFromUriWithOnlyUserAndNoPassword()
@@ -93,14 +93,14 @@ class FunctionalTest extends TestCase
 
         $this->client = new Client('empty@127.0.0.1:' . $this->port, $this->connector);
 
-        $this->assertResolveStream($this->client->create('www.google.com', 80));
+        $this->assertResolveStream($this->client->connect('www.google.com:80'));
     }
 
     public function testConnectionAuthenticationUnused()
     {
         $this->client = new Client('name:pass@127.0.0.1:' . $this->port, $this->connector);
 
-        $this->assertResolveStream($this->client->create('www.google.com', 80));
+        $this->assertResolveStream($this->client->connect('www.google.com:80'));
     }
 
     public function testConnectionInvalidProtocolMismatch()
@@ -109,7 +109,7 @@ class FunctionalTest extends TestCase
 
         $this->server->setProtocolVersion(5);
 
-        $this->assertRejectPromise($this->client->create('127.0.0.1', 80));
+        $this->assertRejectPromise($this->client->connect('127.0.0.1:80'));
     }
 
     public function testConnectionInvalidNoAuthentication()
@@ -118,7 +118,7 @@ class FunctionalTest extends TestCase
 
         $this->server->setAuthArray(array('name' => 'pass'));
 
-        $this->assertRejectPromise($this->client->create('www.google.com', 80));
+        $this->assertRejectPromise($this->client->connect('www.google.com:80'));
     }
 
     public function testConnectionInvalidAuthenticationMismatch()
@@ -127,22 +127,22 @@ class FunctionalTest extends TestCase
 
         $this->server->setAuthArray(array('name' => 'pass'));
 
-        $this->assertRejectPromise($this->client->create('www.google.com', 80));
+        $this->assertRejectPromise($this->client->connect('www.google.com:80'));
     }
 
     public function testConnectorOkay()
     {
-        $this->assertResolveStream($this->client->create('www.google.com', 80));
+        $this->assertResolveStream($this->client->connect('www.google.com:80'));
     }
 
     public function testConnectorInvalidDomain()
     {
-        $this->assertRejectPromise($this->client->create('www.google.commm', 80));
+        $this->assertRejectPromise($this->client->connect('www.google.commm:80'));
     }
 
     public function testConnectorCancelConnection()
     {
-        $promise = $this->client->create('www.google.com', 80);
+        $promise = $this->client->connect('www.google.com:80');
         $promise->cancel();
 
         $this->assertRejectPromise($promise);
@@ -153,7 +153,7 @@ class FunctionalTest extends TestCase
         // time out the connection attempt in 0.1s (as expected)
         $tcp = new TimeoutConnector($this->client, 0.1, $this->loop);
 
-        $this->assertRejectPromise($tcp->create('www.google.com', 8080));
+        $this->assertRejectPromise($tcp->connect('www.google.com:8080'));
     }
 
     public function testSecureConnectorOkay()
@@ -164,7 +164,7 @@ class FunctionalTest extends TestCase
 
         $ssl = new SecureConnector($this->client, $this->loop);
 
-        $this->assertResolveStream($ssl->create('www.google.com', 443));
+        $this->assertResolveStream($ssl->connect('www.google.com:443'));
     }
 
     public function testSecureConnectorToBadSslWithVerifyFails()
@@ -175,7 +175,7 @@ class FunctionalTest extends TestCase
 
         $ssl = new SecureConnector($this->client, $this->loop, array('verify_peer' => true));
 
-        $this->assertRejectPromise($ssl->create('self-signed.badssl.com', 443));
+        $this->assertRejectPromise($ssl->connect('self-signed.badssl.com:443'));
     }
 
     public function testSecureConnectorToBadSslWithoutVerifyWorks()
@@ -186,7 +186,7 @@ class FunctionalTest extends TestCase
 
         $ssl = new SecureConnector($this->client, $this->loop, array('verify_peer' => false));
 
-        $this->assertResolveStream($ssl->create('self-signed.badssl.com', 443));
+        $this->assertResolveStream($ssl->connect('self-signed.badssl.com:443'));
     }
 
     public function testSecureConnectorInvalidPlaintextIsNotSsl()
@@ -197,7 +197,7 @@ class FunctionalTest extends TestCase
 
         $ssl = new SecureConnector($this->client, $this->loop);
 
-        $this->assertRejectPromise($ssl->create('www.google.com', 80));
+        $this->assertRejectPromise($ssl->connect('www.google.com:80'));
     }
 
     public function testSecureConnectorInvalidUnboundPortTimeout()
@@ -207,7 +207,7 @@ class FunctionalTest extends TestCase
         // time out the connection attempt in 0.1s (as expected)
         $ssl = new TimeoutConnector($ssl, 0.1, $this->loop);
 
-        $this->assertRejectPromise($ssl->create('www.google.com', 8080));
+        $this->assertRejectPromise($ssl->connect('www.google.com:8080'));
     }
 
     private function createSocketServer()


### PR DESCRIPTION
```php
// old
$connector = new React\SocketClient\TcpConnector($loop);
$client = new Client(1080, $connector);
$client->create('google.com', 80)->then(function (Stream $conn) {
    $conn->write("…");
});

// new
$connector = new React\Socket\TcpConnector($loop);
$client = new Client(1080, $connector);
$client->connect('google.com:80')->then(function (ConnectionInterface $conn) {
    $conn->write("…");
});
```