### PR TITLE
Updated evenement/evenement to include 3.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=5.3",
         "react/socket": "^1.0 || ^0.8 || ^0.7",
         "react/promise": "^2.1 || ^1.2",
-        "evenement/evenement": "~1.0|~2.0"
+        "evenement/evenement": "~3.0|~1.0|~2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0 || ^4.8",


### PR DESCRIPTION
Took a quick look and it seems `clue/sockets-react` is perfectly compatible with `evenement/evenment` 3.0 (and 2.0 (and 1.0)).