### PR TITLE
Update test environment to fix tests on legacy PHP 7.2 with PHPUnit 8.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,7 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: xdebug
       - run: composer install
-      - run: vendor/bin/phpunit --coverage-text
-        if: ${{ matrix.php >= 7.3 }}
-      - run: vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy
-        if: ${{ matrix.php < 7.3 }}
+      - run: vendor/bin/phpunit --coverage-text ${{ matrix.php < 7.3 && '-c phpunit.xml.legacy' || '' }}
 
   PHPUnit-hhvm:
     name: PHPUnit (HHVM)

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require-dev": {
         "clue/block-react": "^1.5",
         "clue/connection-manager-extra": "^1.3",
-        "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+        "phpunit/phpunit": "^9.6 || ^8.5 || ^5.7 || ^4.8.36",
         "react/event-loop": "^1.2",
         "react/http": "^1.6"
     },


### PR DESCRIPTION
This changeset updates the test environment to fix tests on legacy PHP 7.2 with PHPUnit 8.5. This is needed to run the tests on legacy platforms due to recent upstream changes as discussed in https://github.com/clue/reactphp-redis/pull/180.

Builds on top of https://github.com/clue/reactphp-redis/pull/180 and #113 and others