### PR TITLE
Improve PHP 8.5+ support by avoiding deprecated `setAccessible()` calls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,11 @@ on:
 jobs:
   PHPUnit:
     name: PHPUnit (PHP ${{ matrix.php }})
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         php:
+          - 8.5
           - 8.4
           - 8.3
           - 8.2
@@ -26,7 +27,7 @@ jobs:
           - 5.4
           - 5.3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -37,10 +38,10 @@ jobs:
 
   PHPUnit-hhvm:
     name: PHPUnit (HHVM)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: cp "$(which composer)" composer.phar && ./composer.phar self-update --2.2 # downgrade Composer for HHVM
       - name: Run hhvm composer.phar install
         uses: docker://hhvm/hhvm:3.30-lts-latest

--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,14 @@
     ],
     "require": {
         "php": ">=5.3",
-        "react/promise": "^3.2 || ^2.1 || ^1.2",
-        "react/socket": "^1.16"
+        "react/promise": "^3.3 || ^2.1 || ^1.2",
+        "react/socket": "^1.17"
     },
     "require-dev": {
         "clue/connection-manager-extra": "^1.3",
         "phpunit/phpunit": "^9.6 || ^8.5 || ^5.7 || ^4.8.36",
         "react/async": "^4.3 || ^3 || ^2",
-        "react/event-loop": "^1.2",
+        "react/event-loop": "^1.6",
         "react/http": "^1.11"
     },
     "autoload": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -207,7 +207,9 @@ final class Client implements ConnectorInterface
                 // avoid garbage references by replacing all closures in call stack.
                 // what a lovely piece of code!
                 $r = new \ReflectionProperty('Exception', 'trace');
-                $r->setAccessible(true);
+                if (PHP_VERSION_ID < 80100) {
+                    $r->setAccessible(true);
+                }
                 $trace = $r->getValue($e);
 
                 // Exception trace arguments are not available on some PHP 7.4 installs

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -28,7 +28,9 @@ class ClientTest extends TestCase
         $proxy = new Client('127.0.0.1:1080');
 
         $ref = new \ReflectionProperty($proxy, 'connector');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $connector = $ref->getValue($proxy);
 
         $this->assertInstanceOf('React\Socket\ConnectorInterface', $connector);

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -33,7 +33,9 @@ class ServerTest extends TestCase
         $server = new Server();
 
         $ref = new \ReflectionProperty($server, 'loop');
-        $ref->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible(true);
+        }
         $loop = $ref->getValue($server);
 
         $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);


### PR DESCRIPTION
This changeset improves PHP 8.5+ support by avoiding the deprecated `setAccessible()` call as discussed in https://github.com/clue/framework-x/pull/297.

Builds on top of #123, #122, https://github.com/reactphp/socket/pull/325, https://github.com/reactphp/promise/pull/264, https://github.com/reactphp/event-loop/pull/282, and https://github.com/clue/framework-x/pull/297